### PR TITLE
refactor: debounce resize handler and skip hidden elements

### DIFF
--- a/src/utils/debounce.test.ts
+++ b/src/utils/debounce.test.ts
@@ -1,0 +1,31 @@
+import { debounce } from './debounce';
+
+describe('debounce', () => {
+  test('delays function execution', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  test('cancel prevents execution', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced.cancel();
+    vi.advanceTimersByTime(100);
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+});

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,14 @@
+export const debounce = <T extends (...args: unknown[]) => void>(
+  fn: T,
+  delay: number
+): ((...args: Parameters<T>) => void) & { cancel: () => void } => {
+  let timeoutId: number;
+  const debounced = (...args: Parameters<T>): void => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => fn(...args), delay);
+  };
+  debounced.cancel = (): void => {
+    window.clearTimeout(timeoutId);
+  };
+  return debounced;
+};

--- a/src/utils/wcagEnforcement.test.ts
+++ b/src/utils/wcagEnforcement.test.ts
@@ -1,32 +1,77 @@
-import { enforceWCAGTouchTargets, setupWCAGEnforcement } from './wcagEnforcement';
+import * as wcag from './wcagEnforcement';
+
+const { enforceWCAGTouchTargets, setupWCAGEnforcement } = wcag;
 
 describe('WCAG Enforcement', () => {
-  test('removes resize listener on cleanup', () => {
+  test('removes resize listener and clears timeout on cleanup', () => {
+    vi.useFakeTimers();
     const addSpy = vi.spyOn(window, 'addEventListener');
     const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const enforceSpy = vi.spyOn(wcag, 'enforceWCAGTouchTargets');
 
     const cleanup = setupWCAGEnforcement();
 
     const resizeCall = addSpy.mock.calls.find(call => call[0] === 'resize');
     const handler = resizeCall?.[1] as EventListener;
 
+    enforceSpy.mockClear();
+    window.dispatchEvent(new Event('resize'));
     cleanup();
+    vi.runAllTimers();
 
     expect(removeSpy).toHaveBeenCalledWith('resize', handler);
+    expect(enforceSpy).not.toHaveBeenCalled();
 
     addSpy.mockRestore();
     removeSpy.mockRestore();
+    enforceSpy.mockRestore();
+    vi.useRealTimers();
   });
 
-  test('ignores hidden elements', () => {
+  test('ignores elements hidden in different ways', () => {
+    const displayNoneButton = document.createElement('button');
+    displayNoneButton.style.display = 'none';
+
+    const visibilityHiddenButton = document.createElement('button');
+    visibilityHiddenButton.style.visibility = 'hidden';
+
+    const zeroOpacityButton = document.createElement('button');
+    zeroOpacityButton.style.opacity = '0';
+
+    const visibleButton = document.createElement('button');
+
+    document.body.append(
+      displayNoneButton,
+      visibilityHiddenButton,
+      zeroOpacityButton,
+      visibleButton
+    );
+
+    enforceWCAGTouchTargets();
+
+    expect(displayNoneButton.style.minHeight).toBe('');
+    expect(visibilityHiddenButton.style.minHeight).toBe('');
+    expect(zeroOpacityButton.style.minHeight).toBe('');
+    expect(visibleButton.style.minHeight).not.toBe('');
+
+    document.body.removeChild(displayNoneButton);
+    document.body.removeChild(visibilityHiddenButton);
+    document.body.removeChild(zeroOpacityButton);
+    document.body.removeChild(visibleButton);
+  });
+
+  test('applies min size when element is revealed', () => {
     const button = document.createElement('button');
     button.style.display = 'none';
     document.body.appendChild(button);
 
+    const cleanup = setupWCAGEnforcement();
+
+    button.style.display = 'block';
     enforceWCAGTouchTargets();
+    expect(button.style.minHeight).not.toBe('');
 
-    expect(button.style.minHeight).toBe('');
-
+    cleanup();
     document.body.removeChild(button);
   });
 });

--- a/src/utils/wcagEnforcement.test.ts
+++ b/src/utils/wcagEnforcement.test.ts
@@ -1,0 +1,32 @@
+import { enforceWCAGTouchTargets, setupWCAGEnforcement } from './wcagEnforcement';
+
+describe('WCAG Enforcement', () => {
+  test('removes resize listener on cleanup', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const cleanup = setupWCAGEnforcement();
+
+    const resizeCall = addSpy.mock.calls.find(call => call[0] === 'resize');
+    const handler = resizeCall?.[1] as EventListener;
+
+    cleanup();
+
+    expect(removeSpy).toHaveBeenCalledWith('resize', handler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  test('ignores hidden elements', () => {
+    const button = document.createElement('button');
+    button.style.display = 'none';
+    document.body.appendChild(button);
+
+    enforceWCAGTouchTargets();
+
+    expect(button.style.minHeight).toBe('');
+
+    document.body.removeChild(button);
+  });
+});

--- a/src/utils/wcagEnforcement.ts
+++ b/src/utils/wcagEnforcement.ts
@@ -41,7 +41,7 @@ export const enforceWCAGTouchTargets = (): void => {
     const htmlElement = element as HTMLElement;
 
     // Skip hidden elements
-    if (htmlElement.offsetParent === null && htmlElement.style.display !== 'none') {
+    if (htmlElement.offsetParent === null || htmlElement.style.display === 'none') {
       return;
     }
 
@@ -109,10 +109,11 @@ export const setupWCAGEnforcement = (): (() => void) => {
 
   // Re-run enforcement when the window is resized
   let resizeTimeout: number;
-  window.addEventListener('resize', () => {
+  const resizeHandler = (): void => {
     clearTimeout(resizeTimeout);
     resizeTimeout = window.setTimeout(enforceWCAGTouchTargets, 250);
-  });
+  };
+  window.addEventListener('resize', resizeHandler);
 
   // Re-run enforcement when new content is added (using MutationObserver)
   const observer = new MutationObserver(mutations => {
@@ -150,6 +151,6 @@ export const setupWCAGEnforcement = (): (() => void) => {
   // Cleanup function
   return () => {
     observer.disconnect();
-    window.removeEventListener('resize', enforceWCAGTouchTargets);
+    window.removeEventListener('resize', resizeHandler);
   };
 };

--- a/src/utils/wcagEnforcement.ts
+++ b/src/utils/wcagEnforcement.ts
@@ -3,6 +3,8 @@
  * This utility ensures all interactive elements meet the minimum 44x44px requirement
  */
 
+import { debounce } from './debounce';
+
 export const enforceWCAGTouchTargets = (): void => {
   // WCAG 2.2 AAA Success Criterion 2.5.5: Target Size (Enhanced)
   const MIN_TOUCH_TARGET_SIZE = 44;
@@ -40,15 +42,20 @@ export const enforceWCAGTouchTargets = (): void => {
   elements.forEach(element => {
     const htmlElement = element as HTMLElement;
 
+    const computedStyle = window.getComputedStyle(htmlElement);
+
     // Skip hidden elements
-    if (htmlElement.offsetParent === null || htmlElement.style.display === 'none') {
+    if (
+      htmlElement.hidden ||
+      computedStyle.display === 'none' ||
+      computedStyle.visibility === 'hidden' ||
+      computedStyle.opacity === '0'
+    ) {
       return;
     }
 
-    // Get computed styles
-    const computedStyle = window.getComputedStyle(htmlElement);
-    const currentHeight = parseFloat(computedStyle.height);
-    const currentWidth = parseFloat(computedStyle.width);
+    const currentHeight = parseFloat(computedStyle.height) || 0;
+    const currentWidth = parseFloat(computedStyle.width) || 0;
 
     // Force minimum dimensions if they're too small
     if (currentHeight < minSize || currentWidth < minSize) {
@@ -108,19 +115,15 @@ export const setupWCAGEnforcement = (): (() => void) => {
   }
 
   // Re-run enforcement when the window is resized
-  let resizeTimeout: number;
-  const resizeHandler = (): void => {
-    clearTimeout(resizeTimeout);
-    resizeTimeout = window.setTimeout(enforceWCAGTouchTargets, 250);
-  };
+  const resizeHandler = debounce(enforceWCAGTouchTargets, 250);
   window.addEventListener('resize', resizeHandler);
 
-  // Re-run enforcement when new content is added (using MutationObserver)
+  // Re-run enforcement when new content is added or revealed
+  const mutationHandler = debounce(enforceWCAGTouchTargets, 100);
   const observer = new MutationObserver(mutations => {
     let shouldRerun = false;
     mutations.forEach(mutation => {
       if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-        // Check if any added nodes are interactive elements
         mutation.addedNodes.forEach(node => {
           if (node.nodeType === Node.ELEMENT_NODE) {
             const element = node as Element;
@@ -134,23 +137,37 @@ export const setupWCAGEnforcement = (): (() => void) => {
           }
         });
       }
+      if (mutation.type === 'attributes' && mutation.target instanceof HTMLElement) {
+        const target = mutation.target as HTMLElement;
+        const style = window.getComputedStyle(target);
+        if (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          style.opacity !== '0' &&
+          !target.hidden
+        ) {
+          shouldRerun = true;
+        }
+      }
     });
 
     if (shouldRerun) {
-      // Debounce the enforcement to avoid excessive calls
-      clearTimeout(resizeTimeout);
-      resizeTimeout = window.setTimeout(enforceWCAGTouchTargets, 100);
+      mutationHandler();
     }
   });
 
   observer.observe(document.body, {
     childList: true,
     subtree: true,
+    attributes: true,
+    attributeFilter: ['style', 'class', 'hidden'],
   });
 
   // Cleanup function
   return () => {
     observer.disconnect();
     window.removeEventListener('resize', resizeHandler);
+    resizeHandler.cancel();
+    mutationHandler.cancel();
   };
 };


### PR DESCRIPTION
## Summary
- refactor WCAG enforcement resize logic into named `resizeHandler` and cleanly remove listener
- ignore hidden elements during touch target enforcement
- add unit tests for resize listener cleanup and hidden element handling

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd02e4dae0832ba1bbadc346c4b04a

## Summary by Sourcery

Improve WCAG touch target enforcement by refactoring the resize handler into a named debounce function, fixing hidden element detection, and adding unit tests for listener cleanup and hidden element handling

Bug Fixes:
- Correct hidden element detection to skip elements with display:none or no offsetParent

Enhancements:
- Refactor the WCAG enforcement resize listener into a named debounce handler for clearer setup and teardown

Tests:
- Add unit tests for resize listener cleanup and hidden element handling