### PR TITLE
refactor: debounce resize handler and skip hidden elements

### DIFF
--- a/src/utils/wcagEnforcement.test.ts
+++ b/src/utils/wcagEnforcement.test.ts
@@ -1,0 +1,32 @@
+import { enforceWCAGTouchTargets, setupWCAGEnforcement } from './wcagEnforcement';
+
+describe('WCAG Enforcement', () => {
+  test('removes resize listener on cleanup', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const cleanup = setupWCAGEnforcement();
+
+    const resizeCall = addSpy.mock.calls.find(call => call[0] === 'resize');
+    const handler = resizeCall?.[1] as EventListener;
+
+    cleanup();
+
+    expect(removeSpy).toHaveBeenCalledWith('resize', handler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  test('ignores hidden elements', () => {
+    const button = document.createElement('button');
+    button.style.display = 'none';
+    document.body.appendChild(button);
+
+    enforceWCAGTouchTargets();
+
+    expect(button.style.minHeight).toBe('');
+
+    document.body.removeChild(button);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor WCAG enforcement resize logic into named `resizeHandler` and cleanly remove listener
- ignore hidden elements during touch target enforcement
- add MutationObserver attribute handling without redundant assertions

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd02e4dae0832ba1bbadc346c4b04a

## Summary by Sourcery

Refactor the WCAG touch target enforcement to skip hidden elements, debounce resize-triggered checks, observe attribute changes on interactive elements, and provide a clean teardown of event listeners and observers

New Features:
- Detect attribute mutations on interactive elements and re-run WCAG enforcement

Bug Fixes:
- Skip hidden elements during touch target enforcement

Enhancements:
- Debounce resize events with a named resizeHandler and cleanly remove the listener
- Extend MutationObserver to listen for attribute changes on relevant elements

Tests:
- Add unit tests for WCAG enforcement utilities