### PR TITLE
refactor: use Vite env flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,7 @@ function App(): React.JSX.Element {
       if (!isLoading) {
         setError({ key: 'errors.pdfFailed' });
       }
-      if (process.env.NODE_ENV === 'development') {
+      if (import.meta.env.DEV) {
         console.error('PDF generation error:', err);
       }
     }
@@ -228,7 +228,7 @@ function App(): React.JSX.Element {
       }
       localStorage.setItem('mathgenie-quiz-results', JSON.stringify(results));
     } catch (error) {
-      if (process.env.NODE_ENV === 'development') {
+      if (import.meta.env.DEV) {
         console.warn('Failed to save quiz result:', error);
       }
     }
@@ -652,7 +652,7 @@ function App(): React.JSX.Element {
             </div>
           )}
 
-          {process.env.NODE_ENV === 'production' && (
+          {import.meta.env.PROD && (
             <Suspense fallback={<div>{t('loading.insights')}</div>}>
               <SpeedInsights />
             </Suspense>

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -22,6 +22,10 @@ describe('ErrorBoundary', () => {
     console.error = originalError;
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   test('renders children when there is no error', () => {
     render(
       <ErrorBoundary>
@@ -44,7 +48,7 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText(/Reload Page/)).toBeDefined();
 
     // In development environment, error details should exist
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.DEV) {
       expect(screen.getByText(/Error Details/)).toBeDefined();
     }
   });
@@ -117,8 +121,9 @@ describe('ErrorBoundary', () => {
   });
 
   test('shows error details in development mode', () => {
-    const originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('MODE', 'development');
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('PROD', false);
 
     render(
       <ErrorBoundary>
@@ -128,13 +133,12 @@ describe('ErrorBoundary', () => {
 
     expect(screen.getByText(/Error Details/)).toBeDefined();
     expect(screen.getByText(/Test error/)).toBeDefined();
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   test('hides error details in production mode', () => {
-    const originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('MODE', 'production');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
 
     render(
       <ErrorBoundary>
@@ -143,8 +147,6 @@ describe('ErrorBoundary', () => {
     );
 
     expect(screen.queryByText(/Error Details/)).toBeNull();
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   test('handles error with custom error info', () => {
@@ -213,6 +215,10 @@ describe('ErrorBoundary', () => {
 });
 
 describe('useErrorHandler', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   test('initializes with no error', () => {
     const { result } = renderHook(() => useErrorHandler());
 
@@ -222,9 +228,10 @@ describe('useErrorHandler', () => {
   });
 
   test('handles error in production', () => {
-    const originalEnv = process.env.NODE_ENV;
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('MODE', 'production');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
 
     const TestComponent = () => {
       const { handleError, error } = useErrorHandler();
@@ -248,7 +255,6 @@ describe('useErrorHandler', () => {
 
     expect(consoleSpy).toHaveBeenCalledWith('Application error:', expect.any(Error));
 
-    process.env.NODE_ENV = originalEnv;
     consoleSpy.mockRestore();
   });
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -34,7 +34,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       this.props.onError(error, errorInfo);
     }
 
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.DEV) {
       console.error('ErrorBoundary caught an error:', error, errorInfo);
     }
   }
@@ -55,7 +55,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
             <h2>🚨 Something went wrong</h2>
             <p>We&apos;re sorry, but something unexpected happened.</p>
 
-            {process.env.NODE_ENV === 'development' && this.state.error && (
+            {import.meta.env.DEV && this.state.error && (
               <details className='error-details'>
                 <summary>Error Details (Development)</summary>
                 <pre>{this.state.error.toString()}</pre>
@@ -101,7 +101,7 @@ export const useErrorHandler = (): {
   const handleError = React.useCallback((error: Error): void => {
     setError(error);
 
-    if (process.env.NODE_ENV === 'production') {
+    if (import.meta.env.PROD) {
       console.error('Application error:', error);
     }
   }, []);

--- a/src/components/PerformanceMonitor.test.tsx
+++ b/src/components/PerformanceMonitor.test.tsx
@@ -34,6 +34,7 @@ describe('PerformanceMonitor', () => {
     consoleLogSpy.mockRestore();
     consoleWarnSpy.mockRestore();
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   it('renders children correctly', () => {
@@ -100,8 +101,9 @@ describe('PerformanceMonitor', () => {
   });
 
   it('logs performance metrics in development', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('MODE', 'development');
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('PROD', false);
 
     const mockObserver = new MockPerformanceObserver(() => {});
     const mockEntry = {
@@ -116,13 +118,12 @@ describe('PerformanceMonitor', () => {
         <div>Test</div>
       </PerformanceMonitor>
     );
-
-    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('handles memory monitoring with interval', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('MODE', 'development');
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('PROD', false);
 
     const mockMemory = {
       usedJSHeapSize: 50 * 1048576,
@@ -151,12 +152,12 @@ describe('PerformanceMonitor', () => {
     });
 
     unmount();
-    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('handles production environment with gtag', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('MODE', 'production');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
 
     const mockGtag = vi.fn();
     (global as any).window = { gtag: mockGtag };
@@ -167,13 +168,13 @@ describe('PerformanceMonitor', () => {
       </PerformanceMonitor>
     );
 
-    process.env.NODE_ENV = originalNodeEnv;
     delete (global as any).window;
   });
 
   it('handles entries without value property', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('MODE', 'development');
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('PROD', false);
 
     // Mock window for this test
     Object.defineProperty(global, 'window', {
@@ -195,7 +196,6 @@ describe('PerformanceMonitor', () => {
       </PerformanceMonitor>
     );
 
-    process.env.NODE_ENV = originalNodeEnv;
     delete (global as any).window;
   });
 
@@ -233,8 +233,9 @@ describe('PerformanceMonitor', () => {
   });
 
   it('triggers performance observer callback in development', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('MODE', 'development');
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('PROD', false);
 
     Object.defineProperty(global, 'window', {
       value: {},
@@ -273,13 +274,13 @@ describe('PerformanceMonitor', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith('test-metric: 100ms');
     expect(consoleLogSpy).toHaveBeenCalledWith('test-duration: 200ms');
 
-    process.env.NODE_ENV = originalNodeEnv;
     delete (global as any).window;
   });
 
   it('triggers performance observer callback in production with gtag', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('MODE', 'production');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
 
     const mockGtag = vi.fn();
     Object.defineProperty(global, 'window', {
@@ -320,13 +321,13 @@ describe('PerformanceMonitor', () => {
       non_interaction: true,
     });
 
-    process.env.NODE_ENV = originalNodeEnv;
     delete (global as any).window;
   });
 
   it('handles production environment without gtag', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('MODE', 'production');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
 
     Object.defineProperty(global, 'window', {
       value: {},
@@ -361,13 +362,13 @@ describe('PerformanceMonitor', () => {
       observerCallback!(mockList as any, {} as any);
     }).not.toThrow();
 
-    process.env.NODE_ENV = originalNodeEnv;
     delete (global as any).window;
   });
 
   it('handles entries with undefined/null values', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('MODE', 'production');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
 
     const mockGtag = vi.fn();
     Object.defineProperty(global, 'window', {
@@ -411,7 +412,6 @@ describe('PerformanceMonitor', () => {
       non_interaction: true,
     });
 
-    process.env.NODE_ENV = originalNodeEnv;
     delete (global as any).window;
   });
 });

--- a/src/components/PerformanceMonitor.tsx
+++ b/src/components/PerformanceMonitor.tsx
@@ -30,13 +30,13 @@ const PerformanceMonitor: React.FC<PerformanceMonitorProps> = ({ children }) => 
     const observer = new PerformanceObserver(list => {
       list.getEntries().forEach(entry => {
         // Log performance metrics in development
-        if (process.env.NODE_ENV === 'development') {
+        if (import.meta.env.DEV) {
           const value = 'value' in entry ? (entry as any).value : entry.duration;
           console.log(`${entry.name}: ${value}ms`);
         }
 
         // Report to analytics in production (if needed)
-        if (process.env.NODE_ENV === 'production' && window.gtag) {
+        if (import.meta.env.PROD && window.gtag) {
           const value = 'value' in entry ? (entry as any).value : entry.duration;
           window.gtag('event', 'web_vitals', {
             event_category: 'Performance',
@@ -61,7 +61,7 @@ const PerformanceMonitor: React.FC<PerformanceMonitorProps> = ({ children }) => 
     if (extendedPerformance.memory) {
       const logMemoryUsage = (): void => {
         const memory = extendedPerformance.memory!;
-        if (process.env.NODE_ENV === 'development') {
+        if (import.meta.env.DEV) {
           console.log('Memory usage:', {
             used: Math.round(memory.usedJSHeapSize / 1048576) + ' MB',
             total: Math.round(memory.totalJSHeapSize / 1048576) + ' MB',

--- a/src/hooks/useProblemGenerator.ts
+++ b/src/hooks/useProblemGenerator.ts
@@ -160,7 +160,7 @@ export const useProblemGenerator = (
 
       return { ...messages, warning: messages.warning || warning };
     } catch (err) {
-      if (process.env.NODE_ENV === 'development') {
+      if (import.meta.env.DEV) {
         console.error('Problem generation error:', err);
       }
       return {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -41,7 +41,7 @@ const loadSettings = (): Settings => {
     }
   } catch (error) {
     localStorage.removeItem('mathgenie-settings');
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.DEV) {
       console.warn('Failed to load settings from localStorage:', error);
     }
   }
@@ -55,7 +55,7 @@ export const useSettings = () => {
     try {
       localStorage.setItem('mathgenie-settings', JSON.stringify(settings));
     } catch (error) {
-      if (process.env.NODE_ENV === 'development') {
+      if (import.meta.env.DEV) {
         console.warn('Failed to save settings to localStorage:', error);
       }
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,15 +21,15 @@ root.render(
 );
 
 // Register service worker for offline functionality
-if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
   serviceWorker.register({
     onSuccess: () => {
-      if (process.env.NODE_ENV === 'development') {
+      if (import.meta.env.DEV) {
         console.log('MathGenie is now available offline!');
       }
     },
     onUpdate: () => {
-      if (process.env.NODE_ENV === 'development') {
+      if (import.meta.env.DEV) {
         console.log('New version available! Please refresh the page.');
       }
     },
@@ -37,6 +37,6 @@ if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
 }
 
 // Load web vitals reporting
-if (process.env.NODE_ENV === 'production') {
+if (import.meta.env.PROD) {
   reportWebVitals();
 }

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import {
   trackEvent,
   trackLanguageChange,
@@ -24,12 +25,15 @@ const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 describe('Analytics Utils', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset NODE_ENV to test
-    process.env.NODE_ENV = 'test';
+    // Reset environment to test
+    vi.stubEnv('MODE', 'test');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', false);
   });
 
   afterEach(() => {
     consoleSpy.mockClear();
+    vi.unstubAllEnvs();
   });
 
   describe('trackEvent', () => {
@@ -42,7 +46,9 @@ describe('Analytics Utils', () => {
     });
 
     test('should not track when user has opted out', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue('true');
 
       trackEvent('test-event', { prop: 'value' });
@@ -51,8 +57,6 @@ describe('Analytics Utils', () => {
     });
 
     test('should handle empty properties', () => {
-      process.env.NODE_ENV = 'test';
-
       trackEvent('test-event');
 
       // Should not throw error
@@ -60,8 +64,6 @@ describe('Analytics Utils', () => {
     });
 
     test('should handle various property types', () => {
-      process.env.NODE_ENV = 'test';
-
       trackEvent('test-event', {
         string: 'value',
         number: 42,
@@ -73,7 +75,9 @@ describe('Analytics Utils', () => {
     });
 
     test('should handle localStorage errors gracefully', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockImplementation(() => {
         throw new Error('localStorage error');
       });
@@ -84,7 +88,9 @@ describe('Analytics Utils', () => {
     });
 
     test('should track events in production when not opted out', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue(null);
 
       // Mock gtag
@@ -97,7 +103,9 @@ describe('Analytics Utils', () => {
     });
 
     test('should include user agent and screen info in production', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue(null);
 
       // Mock navigator and screen
@@ -125,7 +133,9 @@ describe('Analytics Utils', () => {
 
   describe('trackProblemGeneration', () => {
     test('should track problem generation with correct properties', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue(null);
 
       const mockGtag = vi.fn();
@@ -152,7 +162,9 @@ describe('Analytics Utils', () => {
 
   describe('trackPdfDownload', () => {
     test('should track PDF download with settings', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue(null);
 
       const mockGtag = vi.fn();
@@ -177,7 +189,9 @@ describe('Analytics Utils', () => {
     });
 
     test('should use default values when not provided', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue(null);
 
       const mockGtag = vi.fn();
@@ -202,7 +216,9 @@ describe('Analytics Utils', () => {
 
   describe('trackLanguageChange', () => {
     test('should track language changes', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue(null);
 
       const mockGtag = vi.fn();
@@ -219,7 +235,9 @@ describe('Analytics Utils', () => {
 
   describe('trackPresetUsed', () => {
     test('should track preset usage', () => {
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('PROD', true);
       localStorageMock.getItem.mockReturnValue(null);
 
       const mockGtag = vi.fn();

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -29,7 +29,7 @@ declare global {
 export const trackEvent = (eventName: string, properties: EventProperties = {}): void => {
   try {
     // Only track in production and if user hasn't opted out
-    if (process.env.NODE_ENV !== 'production' || localStorage.getItem('analytics-opt-out')) {
+    if (!import.meta.env.PROD || localStorage.getItem('analytics-opt-out')) {
       return;
     }
   } catch (error) {
@@ -52,7 +52,7 @@ export const trackEvent = (eventName: string, properties: EventProperties = {}):
   };
 
   // Log to console in development
-  if (process.env.NODE_ENV !== 'production') {
+  if (!import.meta.env.PROD) {
     console.log('Analytics Event:', event);
   }
 

--- a/src/utils/wcagEnforcement.ts
+++ b/src/utils/wcagEnforcement.ts
@@ -99,7 +99,7 @@ export const enforceWCAGTouchTargets = (): void => {
   });
 
   // Add debug information in development
-  if (process.env.NODE_ENV === 'development') {
+  if (import.meta.env.DEV) {
     console.log(
       `WCAG Enforcement: Applied ${minSize}px minimum touch targets to ${elements.length} elements`
     );


### PR DESCRIPTION
## Summary
- use `import.meta.env` instead of `process.env.NODE_ENV` in client code
- stub Vite env vars in unit tests
- keep build scripts relying on Node environment

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd78be4ac0832b868e37abcad21aff