### PR TITLE
docs: add first principles guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 ### Structure Limits (Targets + Caps)
 
 9. **File Size (SLoC)**
+
 ### Dependencies & Boundaries
 
 26. Prefer standard library first. Wrap external calls behind adapters with timeouts, retries, and circuit breakers where applicable.
@@ -30,7 +31,7 @@
 28. Run automated vulnerability scans on dependencies in CI/CD pipeline.
 29. Schedule regular dependency updates (at least monthly) with automated PRs.
 30. Maintain a Software Bill of Materials (SBOM) and audit dependencies for license compliance.
-11. **Directory Hygiene**: aim ≤ 8 items per directory. Group by domain/layer (e.g., `users/`, `billing/`, `adapters/`, `usecases/`). Export a minimal public surface.
+31. **Directory Hygiene**: aim ≤ 8 items per directory. Group by domain/layer (e.g., `users/`, `billing/`, `adapters/`, `usecases/`). Export a minimal public surface.
 
 ### Architecture Principles
 
@@ -40,6 +41,12 @@
 15. Hexagonal layering: domain isolated from frameworks and I/O. Domain code testable without network/DB.
 16. Configuration via environment with schema validation and safe defaults.
 17. Error handling: do not swallow errors; propagate with context; return typed/structured errors; log once.
+
+### First Principles & Pragmatism
+
+17.1. Start from first principles to clarify constraints and intent.
+17.2. Avoid over-engineering: prefer mature libraries and frameworks for routine business logic.
+17.3. Avoid “Not Invented Here”: study existing solutions' principles before choosing to adopt, extend, or rewrite.
 
 ### Code Smells → Immediate Action (with Remedies)
 
@@ -71,9 +78,10 @@
 34. **Run & Test Instructions** (exact commands).
 35. **Assumptions** (bulleted).
 36. **Self-check** (map Review Checklist items to what you did).
-72. **Codemods**: jscodeshift / ts-morph (JS/TS); OpenRewrite (JVM); Bowler/libCST (Python); `rustfix`; `gofix`.
-73. **Security**: Semgrep rulesets; osv-scanner; OWASP Dependency-Check; Trivy (container/SCA); Snyk (SCA/container); GitGuardian (secrets).
-74. **Coverage**: Jest/Vitest + c8; coverage.py; `go test -coverprofile`; tarpaulin (Rust).
+37. **Codemods**: jscodeshift / ts-morph (JS/TS); OpenRewrite (JVM); Bowler/libCST (Python); `rustfix`; `gofix`.
+38. **Security**: Semgrep rulesets; osv-scanner; OWASP Dependency-Check; Trivy (container/SCA); Snyk (SCA/container); GitGuardian (secrets).
+39. **Coverage**: Jest/Vitest + c8; coverage.py; `go test -coverprofile`; tarpaulin (Rust).
+
 ### Review Checklist (Verify Before Returning Output)
 
 38. Lints/formatters clean.
@@ -86,10 +94,11 @@
 ### Deviation Policy
 
 44. If a rule must be broken, add a **`@deviation`** note near the violation including: Rule, Reason, Risk, Refactor Plan (link), Owner, Target date. Keep deviations temporary and tracked.
-86. Tests green and deterministic; changed-line coverage ≥ 80%.
-87. Performance metrics within SLOs; Core Web Vitals pass.
-88. Accessibility: WCAG 2.2 AAA compliance verified.
-89. Errors structured; logging/metrics/traces added where appropriate.
+45. Tests green and deterministic; changed-line coverage ≥ 80%.
+46. Performance metrics within SLOs; Core Web Vitals pass.
+47. Accessibility: WCAG 2.2 AAA compliance verified.
+48. Errors structured; logging/metrics/traces added where appropriate.
+
 ## SYSTEM — Maintenance Playbook for Existing Non-Compliant Code
 
 ### Principles


### PR DESCRIPTION
## Summary
- clarify first principles reasoning expectations
- note to avoid over-engineering by using mature libraries
- warn against "Not Invented Here" when evaluating external solutions

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7a8c8c24832bbf12134461e38249

## Summary by Sourcery

Introduce a new First Principles & Pragmatism section in AGENTS.md, refine list numbering for consistency, and reinforce guidance on avoiding over-engineering and Not Invented Here bias.

Documentation:
- Add a "First Principles & Pragmatism" section with three guidelines on starting from first principles, avoiding over-engineering, and preventing Not Invented Here bias
- Renumber Directory Hygiene and subsequent checklist items for consistent ordering