### PR TITLE
Fix Playwright preview command for tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -483,7 +483,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm preview',
+    command: 'pnpm preview -- --open false',
     url: 'http://localhost:4173',
     reuseExistingServer: !process.env.CI,
     timeout: 180000, // Increased from 120s to 180s for CI stability

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -316,7 +316,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm preview',
+    command: 'pnpm preview -- --open false',
     url: 'http://localhost:4173',
     reuseExistingServer: !process.env.CI,
     timeout: 180000, // Increased from 120s to 180s for CI stability


### PR DESCRIPTION
## Summary
- disable Vite preview's auto-open behaviour so Playwright's webServer no longer crashes in headless environments
- apply the same preview command adjustment to the E2E-specific Playwright config

## Testing
- CI=1 DEBUG=pw:webserver ./node_modules/.bin/playwright test tests/e2e/webkit-specific.spec.ts --config=playwright.config.ts --project="mobile-iphone" --reporter=list

------
https://chatgpt.com/codex/tasks/task_e_68df1636a22c832b9280d46d91dac2a6